### PR TITLE
fix: unify SQLAlchemy base and dynamic error timestamps

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from typing import Union, Dict, Any
 import logging
 import traceback
+from datetime import datetime
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -57,7 +58,8 @@ def create_error_response(
         "error": True,
         "status_code": status_code,
         "message": message,
-        "timestamp": "2024-01-01T00:00:00Z"  # This would be dynamic in real implementation
+        # Include the current UTC time to aid debugging on the client side
+        "timestamp": datetime.utcnow().isoformat() + "Z",
     }
     
     if details:

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,3 +1,14 @@
-from sqlalchemy.ext.declarative import declarative_base
+"""SQLAlchemy declarative base shared across the application.
 
-Base = declarative_base()
+Historically this module defined its own ``declarative_base`` instance.
+That meant tests importing :mod:`app.models.base` ended up operating on a
+different metadata registry than the rest of the application, leading to
+missing tables and inconsistent behaviour.  To ensure a single source of
+truth we now simply expose the ``Base`` class from
+``app.core.database``.
+"""
+
+from app.core.database import Base
+
+__all__ = ["Base"]
+


### PR DESCRIPTION
## Summary
- expose shared SQLAlchemy Base from `app.models.base` to avoid metadata divergence
- include current UTC timestamp in error responses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q fastapi "uvicorn[standard]" sqlalchemy[asyncio] aiosqlite pydantic pydantic-settings "python-jose[cryptography]" "passlib[bcrypt]" python-multipart python-dotenv httpx pytest-asyncio` *(fails: Could not find a version that satisfies the requirement aiosqlite)*

------
https://chatgpt.com/codex/tasks/task_e_688fd543fc70832a8291dcfa6c2939da